### PR TITLE
fix: most NPM modules need CommonJS export syntax

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,7 +7,7 @@ module.exports = function(grunt) {
     },
     copy: {
       npm_dist: { // creates the source file for the npm version
-        src: 'assets/js/atcb.js', 
+        src: 'assets/js/atcb.js',
         dest: 'npm_dist/atcb_npm.js',
         options: {
           process: function (content) {


### PR DESCRIPTION
When trying to use add-to-calendar-button in an NPM project, when this
project does use export/import module syntax, I still got errors that
`export` was not valid.

I believe most projects use CommonJS. I'm using Gatsby, and even though
I use ESM syntax (import/export) throughout my project, it still expects
dependencies to be written in CommonJS syntax.

Looks like the best way is to support both:
https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html